### PR TITLE
[BUGFIX] Fix firewall configuration option value

### DIFF
--- a/www/services/firewall.md
+++ b/www/services/firewall.md
@@ -54,7 +54,7 @@ base::firewall::rules:
   "020 deny HTTP because we want to force a secure site with HTTPS only":
     "chain":  "INPUT"
     "port":   "80"
-    "action": "rejected"
+    "action": "reject"
 ```
 Hint: HTTP(S) nginx rules are numbered 040 so you must use a lower number for your rule to be processed before the default allow all from nginx-configuration
 


### PR DESCRIPTION
It should be "reject" instead of "rejected". With "rejected" puppet says:

  Error: Failed to apply catalog: Parameter action failed on Firewall[080 Deny everybody else https]: Invalid value "rejected". Valid values are accept, reject, drop.  at /home/puppet-git/env/201501_master/modules/base/manifests/firewall/rule.pp:22